### PR TITLE
Change label_dir.py to move images to directories named with the label

### DIFF
--- a/src/label_image.py
+++ b/src/label_image.py
@@ -8,7 +8,7 @@ image_path = sys.argv[1]
 image_data = tf.gfile.FastGFile(image_path, 'rb').read()
 
 # Loads label file, strips off carriage return
-label_lines = [line.rstrip() for line 
+label_lines = [line.rstrip() for line
                    in tf.gfile.GFile("/tf_files/retrained_labels.txt")]
 
 # Unpersists graph from file
@@ -20,13 +20,13 @@ with tf.gfile.FastGFile("/tf_files/retrained_graph.pb", 'rb') as f:
 with tf.Session() as sess:
     # Feed the image_data as input to the graph and get first prediction
     softmax_tensor = sess.graph.get_tensor_by_name('final_result:0')
-    
+
     predictions = sess.run(softmax_tensor, \
              {'DecodeJpeg/contents:0': image_data})
-    
+
     # Sort to show labels of first prediction in order of confidence
     top_k = predictions[0].argsort()[-len(predictions[0]):][::-1]
-    
+
     for node_id in top_k:
         human_string = label_lines[node_id]
         score = predictions[0][node_id]

--- a/src/py/label_dir.py
+++ b/src/py/label_dir.py
@@ -17,6 +17,8 @@ def mkdir_p(path):
 src_dir = '/toScan'
 dest_dir = '/scanned'
 img_files = [f for f in listdir(src_dir) if isfile(join(src_dir, f))]
+issue_dir = join(dest_dir, '_issues')
+mkdir_p(issue_dir)
 
 # Loads label file, strips off carriage return
 label_lines = [line.rstrip() for line
@@ -37,8 +39,14 @@ with tf.Session() as sess:
         image_data =  tf.gfile.FastGFile(src_image_path, 'rb').read()
 
         print(src_image_path)
-        predictions = sess.run(softmax_tensor, \
-                 {'DecodeJpeg/contents:0': image_data})
+
+        try:
+
+            predictions = sess.run(softmax_tensor, \
+                     {'DecodeJpeg/contents:0': image_data})
+        except Exception as e:
+            move(srcFilePath, join(issue_dir, imageFile))
+            continue
 
         # Sort to show labels of first prediction in order of confidence
         top_k = predictions[0].argsort()[-len(predictions[0]):][::-1]

--- a/src/py/label_dir.py
+++ b/src/py/label_dir.py
@@ -12,9 +12,9 @@ from os import listdir
 from os import mkdir
 from shutil import copyfile
 from os.path import isfile, join
-varPath = '/toScan'
-destDir = "/scanned"
-imgFiles = [f for f in listdir(varPath) if isfile(join(varPath, f))]
+var_path = '/toScan'
+dest_dir = "/scanned"
+img_files = [f for f in listdir(var_path) if isfile(join(var_path, f))]
 
 
 # Loads label file, strips off carriage return
@@ -31,15 +31,15 @@ with tf.Session() as sess:
     # Feed the image_data as input to the graph and get first prediction
     softmax_tensor = sess.graph.get_tensor_by_name('final_result:0')
     #try:
-    #    shutil.rmtree(destDir)
+    #    shutil.rmtree(dest_dir)
     #except:
     #    None
     #mkdir ('scanned')
 
-    for imageFile in imgFiles:
-        image_data =  tf.gfile.FastGFile(varPath+"/"+imageFile, 'rb').read()
+    for image_file in img_files:
+        image_data =  tf.gfile.FastGFile(var_path+"/"+image_file, 'rb').read()
 
-        print (varPath+"/"+imageFile)
+        print (var_path+"/"+image_file)
         predictions = sess.run(softmax_tensor, \
                  {'DecodeJpeg/contents:0': image_data})
 
@@ -47,9 +47,9 @@ with tf.Session() as sess:
         top_k = predictions[0].argsort()[-len(predictions[0]):][::-1]
         firstElt = top_k[0];
 
-        newFileName = label_lines[firstElt] +"--"+ str(predictions[0][firstElt])[2:7]+".jpg"
-        print(newFileName)
-        copyfile(varPath+"/"+imageFile, destDir+"/"+newFileName)
+        new_file_name = label_lines[firstElt] +"--"+ str(predictions[0][firstElt])[2:7]+".jpg"
+        print(new_file_name)
+        copyfile(var_path+"/"+image_file, dest_dir+"/"+new_file_name)
 
         for node_id in top_k:
             human_string = label_lines[node_id]

--- a/src/py/label_dir.py
+++ b/src/py/label_dir.py
@@ -1,21 +1,11 @@
 import tensorflow as tf
-import sys
-
-# change this as you see fit
-#image_path = sys.argv[1]
-
-# Read in the image_data
-#image_data = tf.gfile.FastGFile(image_path, 'rb').read()
-import os
-import shutil
-from os import listdir
-from os import mkdir
 from shutil import copyfile
+from os import listdir
 from os.path import isfile, join
+
 var_path = '/toScan'
 dest_dir = '/scanned'
 img_files = [f for f in listdir(var_path) if isfile(join(var_path, f))]
-
 
 # Loads label file, strips off carriage return
 label_lines = [line.rstrip() for line
@@ -30,11 +20,6 @@ with tf.gfile.FastGFile('/tf_files/retrained_graph.pb', 'rb') as f:
 with tf.Session() as sess:
     # Feed the image_data as input to the graph and get first prediction
     softmax_tensor = sess.graph.get_tensor_by_name('final_result:0')
-    #try:
-    #    shutil.rmtree(dest_dir)
-    #except:
-    #    None
-    #mkdir ('scanned')
 
     for image_file in img_files:
         src_image_path = join(var_path, image_file)
@@ -55,5 +40,4 @@ with tf.Session() as sess:
         for node_id in top_k:
             human_string = label_lines[node_id]
             score = predictions[0][node_id]
-            #print (node_id)
             print('%s (score = %.5f)' % (human_string, score))

--- a/src/py/label_dir.py
+++ b/src/py/label_dir.py
@@ -3,9 +3,9 @@ from shutil import copyfile
 from os import listdir
 from os.path import isfile, join
 
-var_path = '/toScan'
+src_dir = '/toScan'
 dest_dir = '/scanned'
-img_files = [f for f in listdir(var_path) if isfile(join(var_path, f))]
+img_files = [f for f in listdir(src_dir) if isfile(join(src_dir, f))]
 
 # Loads label file, strips off carriage return
 label_lines = [line.rstrip() for line
@@ -22,7 +22,7 @@ with tf.Session() as sess:
     softmax_tensor = sess.graph.get_tensor_by_name('final_result:0')
 
     for image_file in img_files:
-        src_image_path = join(var_path, image_file)
+        src_image_path = join(src_dir, image_file)
         image_data =  tf.gfile.FastGFile(src_image_path, 'rb').read()
 
         print src_image_path

--- a/src/py/label_dir.py
+++ b/src/py/label_dir.py
@@ -13,16 +13,16 @@ from os import mkdir
 from shutil import copyfile
 from os.path import isfile, join
 var_path = '/toScan'
-dest_dir = "/scanned"
+dest_dir = '/scanned'
 img_files = [f for f in listdir(var_path) if isfile(join(var_path, f))]
 
 
 # Loads label file, strips off carriage return
 label_lines = [line.rstrip() for line
-                   in tf.gfile.GFile("/tf_files/retrained_labels.txt")]
+                   in tf.gfile.GFile('/tf_files/retrained_labels.txt')]
 
 # Unpersists graph from file
-with tf.gfile.FastGFile("/tf_files/retrained_graph.pb", 'rb') as f:
+with tf.gfile.FastGFile('/tf_files/retrained_graph.pb', 'rb') as f:
     graph_def = tf.GraphDef()
     graph_def.ParseFromString(f.read())
     _ = tf.import_graph_def(graph_def, name='')
@@ -47,7 +47,7 @@ with tf.Session() as sess:
         top_k = predictions[0].argsort()[-len(predictions[0]):][::-1]
         firstElt = top_k[0];
 
-        new_file_name = label_lines[firstElt] +"--"+ str(predictions[0][firstElt])[2:7]+".jpg"
+        new_file_name = label_lines[firstElt] +'--'+ str(predictions[0][firstElt])[2:7]+'.jpg'
         print(new_file_name)
         copyfile(join(var_path, image_file), join(dest_dir, new_file_name))
 

--- a/src/py/label_dir.py
+++ b/src/py/label_dir.py
@@ -18,7 +18,7 @@ imgFiles = [f for f in listdir(varPath) if isfile(join(varPath, f))]
 
 
 # Loads label file, strips off carriage return
-label_lines = [line.rstrip() for line 
+label_lines = [line.rstrip() for line
                    in tf.gfile.GFile("/tf_files/retrained_labels.txt")]
 
 # Unpersists graph from file
@@ -35,14 +35,14 @@ with tf.Session() as sess:
     #except:
     #    None
     #mkdir ('scanned')
- 
+
     for imageFile in imgFiles:
-        image_data =  tf.gfile.FastGFile(varPath+"/"+imageFile, 'rb').read()       
+        image_data =  tf.gfile.FastGFile(varPath+"/"+imageFile, 'rb').read()
 
         print (varPath+"/"+imageFile)
         predictions = sess.run(softmax_tensor, \
                  {'DecodeJpeg/contents:0': image_data})
-        
+
         # Sort to show labels of first prediction in order of confidence
         top_k = predictions[0].argsort()[-len(predictions[0]):][::-1]
         firstElt = top_k[0];

--- a/src/py/label_dir.py
+++ b/src/py/label_dir.py
@@ -37,9 +37,10 @@ with tf.Session() as sess:
     #mkdir ('scanned')
 
     for image_file in img_files:
-        image_data =  tf.gfile.FastGFile(join(var_path, image_file), 'rb').read()
+        src_image_path = join(var_path, image_file)
+        image_data =  tf.gfile.FastGFile(src_image_path, 'rb').read()
 
-        print join(var_path, image_file)
+        print src_image_path
         predictions = sess.run(softmax_tensor, \
                  {'DecodeJpeg/contents:0': image_data})
 
@@ -49,7 +50,7 @@ with tf.Session() as sess:
 
         new_file_name = label_lines[firstElt] +'--'+ str(predictions[0][firstElt])[2:7]+'.jpg'
         print(new_file_name)
-        copyfile(join(var_path, image_file), join(dest_dir, new_file_name))
+        copyfile(src_image_path, join(dest_dir, new_file_name))
 
         for node_id in top_k:
             human_string = label_lines[node_id]

--- a/src/py/label_dir.py
+++ b/src/py/label_dir.py
@@ -37,9 +37,9 @@ with tf.Session() as sess:
     #mkdir ('scanned')
 
     for image_file in img_files:
-        image_data =  tf.gfile.FastGFile(var_path+"/"+image_file, 'rb').read()
+        image_data =  tf.gfile.FastGFile(join(var_path, image_file), 'rb').read()
 
-        print (var_path+"/"+image_file)
+        print join(var_path, image_file)
         predictions = sess.run(softmax_tensor, \
                  {'DecodeJpeg/contents:0': image_data})
 
@@ -49,7 +49,7 @@ with tf.Session() as sess:
 
         new_file_name = label_lines[firstElt] +"--"+ str(predictions[0][firstElt])[2:7]+".jpg"
         print(new_file_name)
-        copyfile(var_path+"/"+image_file, dest_dir+"/"+new_file_name)
+        copyfile(join(var_path, image_file), join(dest_dir, new_file_name))
 
         for node_id in top_k:
             human_string = label_lines[node_id]


### PR DESCRIPTION
This PR changes the `label_dir.py` script so that it moves image rather than copying and renaming them.

It outputs them folder with the label names that that classifier has been trained with. This makes it easier to use the output from the classifier to train it again.

It also adds some error handling for image issues like #5 and refactors the code to be more consistent and pythonic.